### PR TITLE
fix: mass star extinction event recovery (15k → 254k)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@
 
 - Featured in **[The Pragmatic Engineer](https://newsletter.pragmaticengineer.com/p/software-engineering-with-llms-in-2025)** newsletter
 - International speaker ([See my talks](https://github.com/steipete/speaking))
-- 15k+ GitHub stars across projects
+- 254k+ GitHub stars across projects (but who's counting)
 - Bootstrapped PSPDFKit to millions in ARR before exit
 
 ### Media


### PR DESCRIPTION
## The Bug

The Recognition section claims:

> 15k+ GitHub stars across projects

Meanwhile, [OpenClaw](https://github.com/openclaw/openclaw) alone is sitting at **254,136 stars** as of today. This README is underselling you by approximately **239,000 stars**, which I believe qualifies as the most mass undercount since the 2020 census.

## Root Cause

Success. Specifically, mass amounts of it.

## The Fix

```diff
- 15k+ GitHub stars across projects
+ 254k+ GitHub stars across projects (but who's counting)
```

## Impact

- **Severity:** Critical — founder is mass undervaluing himself on his own profile
- **Affected users:** Anyone who reads the README and thinks "only 15k? mid."
- **Blast radius:** Peter's ego (positive direction)

## Testing

```bash
$ gh api repos/openclaw/openclaw --jq .stargazers_count
254136
```

Confirmed: 254,136 > 15,000. Math checks out.

## Checklist

- [x] Verified star count is not hallucinated
- [x] Single-line change
- [x] No breaking changes (unless you count breaking modesty)
- [x] CI should pass (it's a README)