### PR TITLE
docs: replace contribution graph with Gitlyy

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Now at **OpenAI**, working on agents; stewarding **OpenClaw** as open and indepe
 
 ## GitHub Activity
 
-![GitHub Contribution Graph](https://ghchart.rshah.org/steipete)
+![GitHub Contribution Graph](https://gitlyy.vercel.app/api/contribution?username=steipete&hide_border=true)
 
 ## What I'm Doing
 


### PR DESCRIPTION
## Summary

- replace the existing third-party activity renderer with Gitlyy's detailed contribution heatmap
- preserve the current section placement, heading, and accessible alt text
- keep the profile change to one README line

Closes https://github.com/steipete/steipete/issues/14

## Decision context

This is a provider swap, not an additional external request: the README already depended on a dynamic contribution image. The candidate follows the proposal while leaving the surrounding profile design untouched.

Tradeoffs reviewed on June 11, 2026:

- **Reliability:** https://github.com/Chintanpatel24/gitlyy is young (created March 29, 2026; 20 stars when reviewed) and its contribution endpoint parses GitHub's public contribution HTML. That is less proven and more markup-sensitive than the current provider.
- **Freshness:** the live endpoint returned valid SVG with a 30-minute cache policy and served repeat requests through Vercel's cache. Vercel documents the relevant cache behavior at https://vercel.com/docs/caching/cache-control-headers.
- **Privacy:** the request contains only the public username. GitHub's GFM renderer rewrites the external image through Camo, so the service receives the proxy request rather than the reader's browser details. GitHub documents that behavior at https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls.
- **Data:** Gitlyy's sampled yearly total and current-day cell matched GitHub's public contribution page. No authentication or private data is used.

## Verification

- `git diff --check`
- rendered the complete README through GitHub's Markdown API
- confirmed the rendered activity image preserves alt text, responsive sizing, and the canonical Gitlyy URL
- fetched both the canonical endpoint and exact Camo URL: HTTP 200, `image/svg+xml`, valid XML
- rasterized and visually inspected the returned 1878x366 SVG
- checked https://github.com/Chintanpatel24/gitlyy, the live Gitlyy endpoint, and https://github.com/steipete/steipete/issues/14 against the real services
- `autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings
