### PR TITLE
feat: replace ugly punchcard with commit-history graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,14 @@ Now at **OpenAI**, working on agents; stewarding **OpenClaw** as open and indepe
 
 ## GitHub Activity
 
-![GitHub Contribution Graph](https://gitlyy.vercel.app/api/contribution?username=steipete&hide_border=true)
+<div align="center">
+  <a href="https://commit-history.com/steipete">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://commit-history.com/embed/steipete?theme=dark" />
+      <img alt="steipete's commit history" src="https://commit-history.com/embed/steipete" />
+    </picture>
+  </a>
+</div>
 
 ## What I'm Doing
 


### PR DESCRIPTION
The punchard is nice, but it does not showcase your GitHub activity going vertical like openclaw stars did 🚀 lfg! :)

## Before: 

<img width="888" height="271" alt="Screenshot 2026-07-01 at 11 09 21" src="https://github.com/user-attachments/assets/0b332104-307e-4135-89ec-9f4df4db4f4c" />


## After:

<img width="1135" height="497" alt="Screenshot 2026-07-01 at 11 08 01" src="https://github.com/user-attachments/assets/79cc0478-7217-4ce9-ac29-3f9e06001ead" />


Check the GitHub rendered file here for sanity before merging.
https://github.com/peetzweg/steipete/blob/peetzweg-commit-history/README.md#github-activity